### PR TITLE
暂时禁用旧 SourceFusion 的打包

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.9.6-alpha</Version>
+    <Version>1.0.0-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/src/SourceFusion.Tool/SourceFusion.Tool.csproj
+++ b/src/SourceFusion.Tool/SourceFusion.Tool.csproj
@@ -8,7 +8,8 @@
     <RootNamespace>dotnetCampus.SourceFusion</RootNamespace>
     <Product>dotnetCampus.SourceFusion</Product>
     <PackageId>dotnetCampus.SourceFusion</PackageId>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
+    <Version>0.9.6-alpha</Version>
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <Description>
       使代码在编译期执行，以提升运行时效率。

--- a/src/dotnetCampus.Telescope.NuGet/dotnetCampus.Telescope.NuGet.csproj
+++ b/src/dotnetCampus.Telescope.NuGet/dotnetCampus.Telescope.NuGet.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netcoreapp3.1;netstandard2.0;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.0-alpha</Version>
     <PackageId>dotnetCampus.TelescopeSource</PackageId>
     <Product>dotnetCampus.TelescopeSource</Product>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
暂时禁用旧 SourceFusion 的打包，因为：

1. Tag 打包机制仅支持同一个版本号的打包，不支持两个项目不同版本号
2. SourceFusion 和 TelescopeSource 之间为了解决业务方的兼容性问题做的改进，是 API 完全不兼容的，导致名称和版本不能统一
3. TelescopeSource 和 SourceFusion 的发布节奏不一致

如果后续需要再打包 SourceFusion，建议将其 Fork 出来单独改，或者建一个单独的分支对其修改。