### PR TITLE
升级 Microsoft.CodeAnalysis.CSharp 和添加文件范围命名空间支持

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
         include-prerelease: true
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
         include-prerelease: true
 
     - name: Install dotnet tool

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,6 @@
     <RepositoryUrl>https://github.com/dotnet-campus/SourceFusion.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>source;dotnet;nuget;msbuild;compile</PackageTags>
-    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <!-- 现在 VisualStudio 2022 没有带上 .NET Framework 4.5 的负载，为了让大家打开项目就能构建，于是加上这个引用。详细请参阅 https://blog.walterlv.com/post/support-old-netfx-on-vs2022-or-later.html -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/dotnet-campus/SourceFusion.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>source;dotnet;nuget;msbuild;compile</PackageTags>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <!-- 现在 VisualStudio 2022 没有带上 .NET Framework 4.5 的负载，为了让大家打开项目就能构建，于是加上这个引用。详细请参阅 https://blog.walterlv.com/post/support-old-netfx-on-vs2022-or-later.html -->

--- a/src/SourceFusion.Tool/SourceFusion.Tool.csproj
+++ b/src/SourceFusion.Tool/SourceFusion.Tool.csproj
@@ -27,8 +27,8 @@
 
   <ItemGroup>
     <PackageReference Include="dotnetCampus.CommandLine.Source" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" Version="4.5.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" Version="4.5.5" PrivateAssets="All" />
     <Reference Include="System.Web"></Reference>
   </ItemGroup>
 

--- a/src/SourceFusion.Tool/Syntax/CompileTypeVisitor.cs
+++ b/src/SourceFusion.Tool/Syntax/CompileTypeVisitor.cs
@@ -88,6 +88,20 @@ namespace dotnetCampus.SourceFusion.Syntax
         }
 
         /// <summary>
+        ///     获取文件命名空间
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        public override SyntaxNode VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
+        {
+            var nameSyntax = Visit(node.Name);
+            // 命名空间
+            _namespace = nameSyntax.ToFullString().Trim();
+
+            return base.VisitFileScopedNamespaceDeclaration(node);
+        }
+
+        /// <summary>
         ///     获取类
         /// </summary>
         /// <param name="node"></param>

--- a/src/TelescopeSourceGenerator/Analyzers/dotnetCampus.Telescope.SourceGeneratorAnalyzers.csproj
+++ b/src/TelescopeSourceGenerator/Analyzers/dotnetCampus.Telescope.SourceGeneratorAnalyzers.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnetCampus.TelescopeTask/dotnetCampus.TelescopeTask.csproj
+++ b/src/dotnetCampus.TelescopeTask/dotnetCampus.TelescopeTask.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net48</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnetCampus.TelescopeTask/dotnetCampus.TelescopeTask.csproj
+++ b/src/dotnetCampus.TelescopeTask/dotnetCampus.TelescopeTask.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="dotnetCampus.CommandLine" Version="3.3.0" PrivateAssets="all" />
     <PackageReference Include="dotnetCampus.Configurations" Version="1.2.9" PrivateAssets="all" />
     <PackageReference Include="dotnetCampus.MSBuildUtils.Source" Version="1.1.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Walterlv.IO.PackageManagement" Version="5.9.0" PrivateAssets="all" />
   </ItemGroup>
 
@@ -28,5 +28,5 @@
   </ItemGroup>
 
   <!-- 这是为了兼容最新版本的预览版的.NET 6构建 -->
-  <Target Name="GetTargetPath"/>
+  <Target Name="GetTargetPath" />
 </Project>


### PR DESCRIPTION
1. 原来的 Microsoft.CodeAnalysis.CSharp 是 4.2.0 版本的，包含 C# 版本为 C# 10。升级到 4.8.0 以支持 C# 11 和 C# 12 的语法，例如列表模式匹配。如果不升级，在使用列表模式匹配+属性模式匹配时会解析类的范围。
2. 块范围的命名空间与文件范围的命名空间（C# 10 已支持）在语法解析中是不同的语法节点，需要额外添加对文件范围命名空间的处理。